### PR TITLE
Lazy load work images

### DIFF
--- a/src/partials/index/work.pug
+++ b/src/partials/index/work.pug
@@ -30,4 +30,4 @@ section.work.section.js-heading#work(data-speed=0)
           br
           p.text.jp
             span.text__content= item.text
-        img.work__img(src=`images/index/${item.image}` alt=`${item.title}`)
+        img.work__img.lazy(src="https://via.placeholder.com/1920x1000" alt=`${item.title}` data-src=`/images/index/${item.image}`)

--- a/src/scripts/work.js
+++ b/src/scripts/work.js
@@ -7,5 +7,11 @@ export default () => {
         .addClass('is-active')
         .siblings('.js-work-data').show();
     });
+
+  window.addEventListener('load', () => {
+    $('.work').find('.work__img').each((i, el) => {
+      $(el).attr('src', $(el).data('src'));
+    });
+  });
 };
 


### PR DESCRIPTION
## 概要
画像を遅延ロードして、ユーザーが操作可能にする時間を短縮します。
4.4s -> 2.4s に短縮できました。

## before
[![Image from Gyazo](https://i.gyazo.com/939da3c497b6e7e9632f214399bb0da2.png)](https://gyazo.com/939da3c497b6e7e9632f214399bb0da2)

## after
[![Image from Gyazo](https://i.gyazo.com/627fa33b2630cc398ad64ea3a5dbf7db.png)](https://gyazo.com/627fa33b2630cc398ad64ea3a5dbf7db)