### PR TITLE
Feature/lazy load image

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "in-view": "^0.6.1",
     "jquery": "^3.3.1",
     "tippy.js": "^2.6.0",
-    "typed.js": "^2.0.9"
+    "typed.js": "^2.0.9",
+    "vanilla-lazyload": "8.15.2"
   }
 }

--- a/src/layout.pug
+++ b/src/layout.pug
@@ -42,4 +42,4 @@ html(lang="ja")
   body
     block body
 
-    script(src='scripts/app.js')
+    script(async src='scripts/app.js')

--- a/src/partials/index/work.pug
+++ b/src/partials/index/work.pug
@@ -30,6 +30,4 @@ section.work.section.js-heading#work(data-speed=20)
           br
           p.text.jp
             span.text__content= item.text
-        picture.work__img
-          source(type="image/webp" srcset=`/images/index/${item.image}.webp`)
-          img(src=`/images/index/${item.image}.jpg` alt=`${item.title}`)
+        img.work__img.lazy(data-src=`/images/index/${item.image}.jpg` alt=`${item.title}`)

--- a/src/scripts/work.js
+++ b/src/scripts/work.js
@@ -1,7 +1,8 @@
-/* global inView */
+/* global inView, LazyLoad */
 
 import $ from 'jquery';
 import inView from 'in-view';
+import LazyLoad from 'vanilla-lazyload';
 
 export default () => {
   inView('.work__item:not(:first-child) > .work__img')
@@ -10,5 +11,10 @@ export default () => {
         .addClass('is-active')
         .siblings('.js-work-data').show();
     });
+
+  const myLazyLoad = new LazyLoad({
+    elements_selector: '.lazy',
+    to_webp: true,
+  });
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7599,6 +7599,10 @@ value-or-function@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/value-or-function/-/value-or-function-3.0.0.tgz#1c243a50b595c1be54a754bfece8563b9ff8d813"
 
+vanilla-lazyload@8.15.2:
+  version "8.15.2"
+  resolved "https://registry.yarnpkg.com/vanilla-lazyload/-/vanilla-lazyload-8.15.2.tgz#76bfd95c40458ecb3d8d28101a494fcdd9e499d1"
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"


### PR DESCRIPTION
## 概要
[lazyload](https://github.com/verlok/lazyload) を利用して、Work セクションにあるスクリーンショット画像を遅延読み込みします。

## 補足
minify された lazyload を import した状態で uglify するとエラーとなりました。
`node_modules` 以下にある loazyload の `package.json` を編集して、import 時は minify していない `lazyload.js` が読み込まれるように修正しました。
`node_modules` を再インストールした際には、そのような対応が必要です。