### PR TITLE
Change Japanese font

### DIFF
--- a/src/layout.pug
+++ b/src/layout.pug
@@ -35,6 +35,7 @@ html(lang="ja")
     script(async src='scripts/app.js')
 
     noscript(id="deferred-styles")
+      link(href="https://fonts.googleapis.com/css?family=Sawarabi+Gothic" rel="stylesheet")
       link(href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet")
       link(rel="stylesheet" type="text/css" href="/styles/app.css")
 

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -4,7 +4,7 @@ html {
 
 body {
   margin: 0;
-  font-family: 'Inconsolata', monospace;
+  font-family: 'Inconsolata', 'Sawarabi Gothic', monospace, sans-serif;
   font-size: 1.2rem;
   line-height: 1.7;
 }

--- a/src/styles/common/_jp.scss
+++ b/src/styles/common/_jp.scss
@@ -1,5 +1,5 @@
 .jp {
-  font-family: "Yu Gothic", YuGothic, "ヒラギノ角ゴ ProN W3", Hiragino Kaku Gothic ProN, Arial, "メイリオ", Meiryo, sans-serif;
+  font-family: 'Sawarabi Gothic', "Yu Gothic", YuGothic, "ヒラギノ角ゴ ProN W3", Hiragino Kaku Gothic ProN, Arial, "メイリオ", Meiryo, sans-serif;
   font-size: 0.9rem;
   letter-spacing: 0.08em;
   line-height: 2.2;


### PR DESCRIPTION
## 概要
日本語フォントを google font の Sawanobori Gothic に変更しました。
どのようなデバイスでみても同じフォントを使用して統一感を出すため。
また日本語Webフォントのパフォーマンスの実験も兼ねています。