### PR TITLE
外部リンクに `noopener` 属性を追加

### DIFF
--- a/src/partials/index/contact.pug
+++ b/src/partials/index/contact.pug
@@ -18,10 +18,10 @@ section.section.contact.js-heading#contact(data-speed=20)
     each item in items
       li.contact__item
         if item.name === 'mail'
-          a(href=`${item.url}`)
+          a(href=`${item.url}` rel="noopener")
             svg.contact__icon(viewbox="0 0 16 16" class=`contact__icon--${item.name}`)
               use(xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=`#${item.name}`)
         else
-          a(href=`${item.url}` target="_blank")
+          a(href=`${item.url}` target="_blank" rel="noopener")
             svg.contact__icon(viewbox="0 0 16 16" class=`contact__icon--${item.name}`)
               use(xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=`#${item.name}`)

--- a/src/partials/index/history.pug
+++ b/src/partials/index/history.pug
@@ -26,5 +26,5 @@ section.section.history.js-heading#history(data-speed=20)
             br
           span.text
             span.text__content
-              a.history__btn.link(href=`${his.url}` target="_blank") more
+              a.history__btn.link(href=`${his.url}` target="_blank" rel="noopener") more
 

--- a/src/partials/index/work.pug
+++ b/src/partials/index/work.pug
@@ -26,7 +26,7 @@ section.work.section.js-heading#work(data-speed=20)
           p.text.text--url
             span.text__content.text__content--url
               | url:&nbsp;
-              a.link(href=`${item.url}` target="_blank")= item.url
+              a.link(href=`${item.url}` target="_blank" rel="noopener")= item.url
           br
           p.text.jp
             span.text__content= item.text


### PR DESCRIPTION
## 概要
Google の lighthouse でサイト解析した際に、外部リンクに `noopener` 属性がないという警告がでました。
セキュリティー的につけておいて方が良いので、外部リンクに `noopener` をつけました。

[参考]
- https://developers.google.com/web/tools/lighthouse/audits/noopener
- https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/