### PR TITLE
Cache the Next.js build folder in Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
 [build]
   command = "yarn build && yarn export"
   publish = "out"
+
+[[plugins]]
+package = "netlify-plugin-cache-nextjs"


### PR DESCRIPTION
Netlify のビルドで以下の Warning が出ていました。
https://app.netlify.com/teams/shgtkshruch/builds/5edc7e7205042bb3e58e1617
```
2:43:33 PM: $ next build
2:43:34 PM: Warning: No build cache found. Please configure build caching for faster rebuilds. Read more: https://err.sh/next.js/no-cache
```

Next.js のビルドキャッシュが有効になっていませんでした。
Netlify では公式プラグインで対応できるようなので、プラグインを有効にしました。
- https://github.com/vercel/next.js/blob/master/errors/no-cache.md
- https://github.com/pizzafox/netlify-cache-nextjs#readme

プラグインを有効にするために Build image を Ubuntu Trusty 14.04 -> Ubuntu Xenial 16.04 (default) に変更しました。