### PR TITLE
Remove `next export` to fix build warning

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "yarn build && yarn export"
+  command = "yarn build"
   publish = "out"
 
 [[plugins]]


### PR DESCRIPTION
https://github.com/vercel/next.js/blob/master/errors/api-routes-static-export.md