### PR TITLE
Dynamic import

### DIFF
--- a/components/contact/index.tsx
+++ b/components/contact/index.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import styled from '@emotion/styled'
+import dynamic from 'next/dynamic'
 
 import { mq } from '../variables'
-import Section from '../common/Section'
-import Heading from '../common/Hgroup'
-import Item from './Item'
+const Section = dynamic(() => import('../common/Section'))
+const Heading = dynamic(() => import('../common/Hgroup'))
+const Item = dynamic(() => import('./Item'))
 
 const List = styled.ul`
   display: flex;

--- a/components/history/Item.tsx
+++ b/components/history/Item.tsx
@@ -1,10 +1,11 @@
 /** @jsx jsx */
 import styled from '@emotion/styled'
 import { jsx, css } from '@emotion/core'
+import dynamic from 'next/dynamic'
 
 import { mq } from '../variables'
-import Link from '../common/Link'
-import Text from '../common/Text'
+const Link = dynamic(() => import('../common/Link'))
+const Text = dynamic(() => import('../common/Text'))
 
 const nthChildAnimation = Array.from('_'.repeat(7)).reduce((res, _, i) => {
   const delay = 0.9 + 0.12 * i

--- a/components/history/index.tsx
+++ b/components/history/index.tsx
@@ -2,11 +2,12 @@
 import { useState } from 'react'
 import styled from '@emotion/styled'
 import { jsx, css } from '@emotion/core'
+import dynamic from 'next/dynamic'
 
 import { breakpoints, mq } from '../variables'
-import Section from '../common/Section'
-import Heading from '../common/Hgroup'
-import Item from './Item'
+const Section = dynamic(() => import('../common/Section'))
+const Heading = dynamic(() => import('../common/Hgroup'))
+const Item = dynamic(() => import('./Item'))
 
 type ListProps = {
   typingDone: boolean

--- a/components/intro/index.tsx
+++ b/components/intro/index.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import styled from '@emotion/styled'
+import dynamic from 'next/dynamic'
 
-import Hgroup from '../common/Hgroup'
-import Mouse from './Mouse'
+const Hgroup = dynamic(() => import('../common/Hgroup'))
+const Mouse = dynamic(() => import('./Mouse'))
 
 const Section = styled.section`
   position: relative;

--- a/components/skill/index.tsx
+++ b/components/skill/index.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import styled from '@emotion/styled'
+import dynamic from 'next/dynamic'
 
 import { mq } from '../variables'
-import Section from '../common/Section'
-import Heading from '../common/Hgroup'
-import Item from './Item'
+const Section = dynamic(() => import('../common/Section'))
+const Heading = dynamic(() => import('../common/Hgroup'))
+const Item = dynamic(() => import('./Item'))
 
 const List = styled.ul`
   display: flex;

--- a/components/work/Item.tsx
+++ b/components/work/Item.tsx
@@ -2,12 +2,12 @@
 import { useState } from 'react'
 import styled from '@emotion/styled'
 import { jsx, css } from '@emotion/core'
-
 import { InView } from 'react-intersection-observer'
+import dynamic from 'next/dynamic'
 
 import { mq } from '../variables'
-import Text from '../common/Text'
-import Link from '../common/Link'
+const Text = dynamic(() => import('../common/Text'))
+const Link = dynamic(() => import('../common/Link'))
 
 const itemStyle = css`
   display: flex;

--- a/components/work/index.tsx
+++ b/components/work/index.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import styled from '@emotion/styled'
+import dynamic from 'next/dynamic'
 
 import { mq } from '../variables'
-import Section from '../common/Section'
-import Heading from '../common/Hgroup'
-import Item from './Item'
+const Section = dynamic(() => import('../common/Section'))
+const Heading = dynamic(() => import('../common/Hgroup'))
+const Item = dynamic(() => import('./Item'))
 
 const List = styled.div`
   padding-top: 4rem;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react'
 import { Global, css } from '@emotion/core'
+import dynamic from 'next/dynamic'
 
 import Head from 'next/head'
-import Container from '../components/layout/Container'
-import Intro from '../components/intro'
-import Work from '../components/work'
-import History from '../components/history'
-import Skill from '../components/skill'
-import Contact from '../components/contact'
-import Footer from '../components/footer'
-import ColorTheme from '../components/common/ColorTheme'
-import GitHubCorner from '../components/common/GitHub-Corner'
+const Container = dynamic(() => import('../components/layout/Container'))
+const Intro = dynamic(() => import('../components/intro'))
+const Work = dynamic(() => import('../components/work'))
+const History = dynamic(() => import('../components/history'))
+const Skill = dynamic(() => import('../components/skill'))
+const Contact = dynamic(() => import('../components/contact'))
+const Footer = dynamic(() => import('../components/footer'))
+const ColorTheme = dynamic(() => import('../components/common/ColorTheme'))
+const GitHubCorner = dynamic(() => import('../components/common/GitHub-Corner'))
 import { mq, theme } from '../components/variables'
 
 export default function Home({ works, history, skills, contacts }) {


### PR DESCRIPTION
https://nextjs.org/docs/advanced-features/dynamic-import

変更の前後で pagespeed insight を複数回実行しましが、速度改善は見られませんでした。
1ページしかないので、スクロールに連動した遅延ローディングのほうが効果がありそう。

## Before
![スクリーンショット 2020-08-19 20 56 34](https://user-images.githubusercontent.com/5207601/90631918-81296b80-e25e-11ea-85fd-2d47df354198.png)

## After
![スクリーンショット 2020-08-19 20 56 28](https://user-images.githubusercontent.com/5207601/90631922-84245c00-e25e-11ea-9c3a-4eb619907a0e.png)
